### PR TITLE
Add speaker tone driver for devices without a buzzer

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -298,6 +298,11 @@ The application allows you to specify the following settings:
   whether to play variometer tones
 - `Vario Vibrations`:
   whether to use variometer vibrations
+- `Sound Driver`
+  Setting this to `Buzzer` will use custom frequency curves played with a buzzer for variometer tones,
+  but some devices do not have a buzzer and can only play system sounds, for this use `Speaker` driver.
+  This will try to *poorly* emulate vario sounds using system sounds and the speaker. Only use this setting
+  if buzzer does not work. 
 - `Minimum Climb`:
   the minimum vertical speed required to play variometer tones and/or
   vibrations
@@ -482,8 +487,8 @@ If you have a better algo in mind, please let me know!!
 
 As of version 2.20, this application has been made to support some touchscreen
 models. However, use of those models can be confusing, and the watches don't
-provide alert tones (so there are no vario tones, only vibrations! ([bug tracker](https://forums.garmin.com/developer/connect-iq/i/bug-reports/attention-playtone-not-fully-suported-on-venu-3))).
-The below guide still applies, however the controls are different
+provide alert tones, so there are no vario tones, only vibrations. However some approximation of vario tones can be made using system sounds (check [Settings](#settings) -> [Sounds](#sounds) -> `Sound Driver`). ([bug tracker](https://forums.garmin.com/developer/connect-iq/i/bug-reports/attention-playtone-not-fully-suported-on-venu-3)).
+This guide still applies, however the controls are different
 - The Back button is unchanged (bottom right) and can be used to change settings
 - The UP and DOWN buttons (middle left and bottom left on 5 button watches) are
 replaced by SWIPE UP and SWIPE DOWN gestures on the screen

--- a/resources/properties.xml
+++ b/resources/properties.xml
@@ -15,6 +15,7 @@
   <!-- ... sounds -->
   <property id="userSoundsVariometerTones" type="boolean">true</property>
   <property id="userVariometerVibrations" type="boolean">true</property>
+  <property id="userSoundsToneDriver" type="number">0</property>
   <property id="userMinimumClimb" type="number">2</property> 
   <property id="userMinimumSink" type="number">1</property> 
   <!-- ... activity -->

--- a/resources/strings.xml
+++ b/resources/strings.xml
@@ -31,6 +31,7 @@
   <string id="titleSettingsSounds">Sounds</string>
   <string id="titleSoundsVariometerTones">Variometer Tones</string>
   <string id="titleVariometerVibrations">Vario Vibrations</string>
+  <string id="titleSoundsToneDriver">Tone Driver</string>
   <string id="titleMinimumClimb">Min. Climb</string>
   <string id="titleMinimumSink">Min. Sink</string>
   <!-- Menu (settings:activity) -->

--- a/source/MySettings.mc
+++ b/source/MySettings.mc
@@ -60,6 +60,7 @@ class MySettings {
   // ... sounds
   public var bSoundsVariometerTones as Boolean = true;
   public var bVariometerVibrations as Boolean = true;
+  public var iSoundsToneDriver as Number = 0; // 0: buzzer, 1: speaker
   public var iMinimumClimb as Number = 2; // Default value of 0.2m/s climb threshold before sounds and vibrations are triggered
   public var iMinimumSink as Number = 1;
   // ... activity
@@ -132,6 +133,7 @@ class MySettings {
     // ... sounds and vibration
     self.setSoundsVariometerTones(self.loadSoundsVariometerTones());
     self.setVariometerVibrations(self.loadVariometerVibrations());
+    self.setSoundsToneDriver(self.loadSoundsToneDriver());
     self.setMinimumClimb(self.loadMinimumClimb());
     self.setMinimumSink(self.loadMinimumSink());
     // ... activity
@@ -346,6 +348,22 @@ class MySettings {
   }
   function setVariometerVibrations(_bValue as Boolean) as Void {
     self.bVariometerVibrations = _bValue;
+  }
+
+  function loadSoundsToneDriver() as Number {
+    return LangUtils.readKeyNumber(App.Properties.getValue("userSoundsToneDriver"), 0);
+  }
+  function saveSoundsToneDriver(_iValue as Number) as Void {
+    App.Properties.setValue("userSoundsToneDriver", _iValue as App.PropertyValueType);
+  }
+  function setSoundsToneDriver(_iValue as Number) as Void {
+    if(_iValue > 1) {
+      _iValue = 1;
+    }
+    else if(_iValue < 0) {
+      _iValue = 0;
+    }
+    self.iSoundsToneDriver = _iValue;
   }
 
   function loadMinimumClimb() as Number { 

--- a/source/menus/generic/MyMenuGeneric.mc
+++ b/source/menus/generic/MyMenuGeneric.mc
@@ -90,6 +90,7 @@ class MyMenuGeneric extends Ui.Menu {
       Menu.setTitle(Ui.loadResource(Rez.Strings.titleSettingsSounds) as String);
       Menu.addItem(Ui.loadResource(Rez.Strings.titleSoundsVariometerTones) as String, :menuSoundsVariometerTones);
       Menu.addItem(Ui.loadResource(Rez.Strings.titleVariometerVibrations) as String, :menuVariometerVibrations);
+      Menu.addItem(Ui.loadResource(Rez.Strings.titleSoundsToneDriver) as String, :menuSoundsToneDriver);
       Menu.addItem(Ui.loadResource(Rez.Strings.titleMinimumClimb) as String, :menuMinimumClimb);
       Menu.addItem(Ui.loadResource(Rez.Strings.titleMinimumSink) as String, :menuMinimumSink);
     }
@@ -303,6 +304,11 @@ class MyMenuGenericDelegate extends Ui.MenuInputDelegate {
       else if(_item == :menuVariometerVibrations) {
         Ui.pushView(new MyPickerGenericOnOff(:contextSettings, :itemVariometerVibrations),
                     new MyPickerGenericOnOffDelegate(:contextSettings, :itemVariometerVibrations),
+                    Ui.SLIDE_IMMEDIATE);
+      }
+      else if (_item == :menuSoundsToneDriver) {
+        Ui.pushView(new MyPickerGenericSettings(:contextSounds, :itemSoundsToneDriver),
+                    new MyPickerGenericSettingsDelegate(:contextSounds, :itemSoundsToneDriver),
                     Ui.SLIDE_IMMEDIATE);
       }
       else if(_item == :menuMinimumClimb) {

--- a/source/menus/generic/MyPickerGenericSettings.mc
+++ b/source/menus/generic/MyPickerGenericSettings.mc
@@ -45,7 +45,21 @@ class MyPickerGenericSettings extends Ui.Picker {
   //
 
   function initialize(_context as Symbol, _item as Symbol) {
-    if(_context == :contextVariometer) {
+    if (_context == :contextSounds) {
+      if (_item == :itemSoundsToneDriver) {
+        var iSoundToneDriver = $.oMySettings.loadSoundsToneDriver();
+        var oFactory = new PickerFactoryDictionary([0, 1], ["Buzzer", "Speaker"], null);
+        Picker.initialize({
+            :title => new Ui.Text({
+                :text => Ui.loadResource(Rez.Strings.titleSoundsToneDriver) as String,
+                :font => Gfx.FONT_TINY,
+                :locX=>Ui.LAYOUT_HALIGN_CENTER,
+                :locY=>Ui.LAYOUT_VALIGN_BOTTOM}),
+            :pattern => [oFactory],
+            :defaults => [oFactory.indexOfKey(iSoundToneDriver)]});
+      }
+    }
+    else if(_context == :contextVariometer) {
 
       if(_item == :itemRange) {
         var iVariometerRange = $.oMySettings.loadVariometerRange();
@@ -356,7 +370,12 @@ class MyPickerGenericSettingsDelegate extends Ui.PickerDelegate {
   }
 
   function onAccept(_amValues) {
-    if(self.context == :contextVariometer) {
+    if (self.context == :contextSounds) {
+      if (self.item == :itemSoundsToneDriver) {
+        $.oMySettings.saveSoundsToneDriver(_amValues[0] as Number);
+      }
+    }
+    else if(self.context == :contextVariometer) {
 
       if(self.item == :itemRange) {
         $.oMySettings.saveVariometerRange(_amValues[0] as Number);


### PR DESCRIPTION
Some devices (like my Venu 3) can not play custom tone profiles, only system sounds.  This PR implements a new tone driver that uses system sounds which can be played using the speaker instead of the buzzer for approximation of vario tones. Hopefully this wont be needed in the future as I made a [bug report](https://forums.garmin.com/developer/connect-iq/i/bug-reports/attention-playtone-not-fully-suported-on-venu-3) on garmin forums, which will hopefully lead to a fix in the SDK.