### PR TITLE
[Fix #10] Update MyKalmanFilter.mc ACCELERATION_VARIANCE value

### DIFF
--- a/source/MyKalmanFilter.mc
+++ b/source/MyKalmanFilter.mc
@@ -34,7 +34,7 @@ class MyKalmanFilter {
   // CONSTANTS
   //
 
-  private const ACCELERATION_VARIANCE = 0.36; //Value 0.36 taken from Arduino-vario, when no accelerometer present (as of now, because gyro data isn't accessible, the watch accelerometer can't be used)
+  private const ACCELERATION_VARIANCE = 0.6; //Value 0.6 taken from Arduino-vario, when no accelerometer present (as of now, because gyro data isn't accessible, the watch accelerometer can't be used)
 
   //
   // VARIABLES


### PR DESCRIPTION
Switch to original code ACCELERATION_VARIANCE value of 0.6 when no accelerometer data is accessible

In the original code, defined value are 
```C++
#ifdef HAVE_ACCELEROMETER 
#define ACCELERATION_MEASURE_STANDARD_DEVIATION 0.3
#else
#define ACCELERATION_MEASURE_STANDARD_DEVIATION 0.6
```